### PR TITLE
Fix HMR on Browser.Application with --debug

### DIFF
--- a/test/fixtures/DebugBrowserApplication.elm
+++ b/test/fixtures/DebugBrowserApplication.elm
@@ -1,0 +1,136 @@
+module DebugBrowserApplication exposing (..)
+
+import Browser exposing (UrlRequest)
+import Browser.Navigation as Nav
+import Html exposing (a, button, div, h1, p, span, text)
+import Html.Attributes exposing (href, id)
+import Html.Events exposing (onClick)
+import Url exposing (Url)
+
+
+main =
+    Browser.application
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = \_ -> Sub.none
+        , onUrlRequest = LinkClicked
+        , onUrlChange = UrlChanged
+        }
+
+
+type alias Flags =
+    { n : Int }
+
+
+type alias Model =
+    { count : Int
+    , myNavKey : Nav.Key
+    , page : Page
+    }
+
+
+type Page
+    = NotFound
+    | Incrementer
+    | Decrementer
+
+
+init : Flags -> Url -> Nav.Key -> ( Model, Cmd Msg )
+init flags url key =
+    ( loadPage url
+        { count = flags.n
+        , myNavKey = key
+        , page = NotFound
+        }
+    , Cmd.none
+    )
+
+
+type Msg
+    = Increment
+    | Decrement
+    | LinkClicked UrlRequest
+    | UrlChanged Url
+
+
+update msg model =
+    case msg of
+        Increment ->
+            ( { model | count = model.count + 1 }
+            , Cmd.none
+            )
+
+        Decrement ->
+            ( { model | count = model.count - 1 }
+            , Cmd.none
+            )
+
+        LinkClicked req ->
+            case req of
+                Browser.Internal url ->
+                    ( model, Nav.pushUrl model.myNavKey (Url.toString url) )
+
+                Browser.External href ->
+                    ( model, Nav.load href )
+
+        UrlChanged url ->
+            ( loadPage url model
+            , Cmd.none
+            )
+
+
+loadPage : Url -> Model -> Model
+loadPage url model =
+    { model
+        | page =
+            case url.fragment of
+                Nothing ->
+                    Incrementer
+
+                Just "/incrementer" ->
+                    Incrementer
+
+                Just "/decrementer" ->
+                    Decrementer
+
+                _ ->
+                    NotFound
+    }
+
+
+view model =
+    let
+        pageBody =
+            case model.page of
+                Incrementer ->
+                    div [ id "incrementer" ]
+                        [ h1 [] [ text "Incrementer" ]
+                        , p []
+                            [ text "Counter value is: "
+                            , span [ id "counter-value" ] [ text (String.fromInt model.count) ]
+                            ]
+                        , button [ onClick Increment, id "counter-button" ] [ text "+" ]
+                        , p [] [ text "Switch to ", a [ id "nav-decrement", href "#/decrementer" ] [ text "decrementer" ] ]
+                        ]
+
+                Decrementer ->
+                    div [ id "decrementer" ]
+                        [ h1 [] [ text "Decrementer" ]
+                        , p []
+                            [ text "Counter value is: "
+                            , span [ id "counter-value" ] [ text (String.fromInt model.count) ]
+                            ]
+                        , button [ onClick Decrement, id "counter-button" ] [ text "-" ]
+                        , p [] [ text "Switch to ", a [ id "nav-increment", href "#/incrementer" ] [ text "incrementer" ] ]
+                        ]
+
+                NotFound ->
+                    text "Page not found"
+    in
+    { title = "DebugBrowserApplication"
+    , body =
+        [ span [ id "code-version" ] [ text "code: v1" ]
+        , pageBody
+        ]
+    }

--- a/test/fixtures/DebugBrowserApplication.html
+++ b/test/fixtures/DebugBrowserApplication.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Main</title>
+    <script type="text/javascript" src="runtime.js"></script>
+    <script type="text/javascript" src="build/DebugBrowserApplication.js"></script>
+</head>
+
+<body>
+<script>
+    connect("DebugBrowserApplication");
+    Elm.DebugBrowserApplication.init({
+        flags: {
+            n: 0
+        }
+    });
+</script>
+</body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -29,34 +29,7 @@ test('counter HMR preserves count (Browser.sandbox)', async t => {
 });
 
 test('counter HMR preserves count (Browser.application)', async t => {
-    const testName = "BrowserApplicationCounter";
-    const page = t.context.page;
-    await page.goto(`${t.context.serverUrl}/${testName}.html`);
-
-    const inc = "#incrementer ";
-    const dec = "#decrementer ";
-
-    await checkCodeVersion(t, page, "v1");
-    await stepTheCounter(t, page, 1, inc);
-    await stepTheCounter(t, page, 2, inc);
-    await stepTheCounter(t, page, 3, inc);
-    await clickLink(page, "#nav-decrement");
-    await stepTheCounter(t, page, 2, dec);
-    await modifyElmCode(t, testName, page, "v1", "v2");
-    await stepTheCounter(t, page, 1, dec);
-    await clickLink(page, "#nav-increment");
-    await stepTheCounter(t, page, 2, inc);
-    await modifyElmCode(t, testName, page, "v2", "v3");
-    await stepTheCounter(t, page, 3, inc);
-    await stepTheCounter(t, page, 4, inc);
-    await modifyElmCode(t, testName, page, "v3", "v4");
-    await stepTheCounter(t, page, 5, inc);
-    await modifyElmCode(t, testName, page, "v4", "v5");
-    await clickLink(page, "#nav-decrement");
-    await stepTheCounter(t, page, 4, dec);
-    await stepTheCounter(t, page, 3, dec);
-    await clickLink(page, "#nav-increment");
-    await stepTheCounter(t, page, 4, inc);
+    await doBrowserApplicationTest(t, "BrowserApplicationCounter");
 });
 
 test('multiple Elm Main modules', async t => {
@@ -94,6 +67,10 @@ test('counter HMR preserves count (embed app in DOM with debugger)', async t => 
 
 test('counter HMR preserves count (fullscreen app in DOM with debugger)', async t => {
     await doCounterTest(t, "DebugFullscreen");
+});
+
+test('counter HMR preserves count (Browser.application with debugger)', async t => {
+    await doBrowserApplicationTest(t, "DebugBrowserApplication");
 });
 
 test('pending async tasks are cancelled when HMR is performed', async t => {
@@ -146,6 +123,36 @@ async function doCounterTest(t, testName) {
     await stepTheCounter(t, page, 7);
     await modifyElmCode(t, testName, page, "v4", "v5");
     await stepTheCounter(t, page, 8);
+}
+
+async function doBrowserApplicationTest(t, testName) {
+    const page = t.context.page;
+    await page.goto(`${t.context.serverUrl}/${testName}.html`);
+
+    const inc = "#incrementer ";
+    const dec = "#decrementer ";
+
+    await checkCodeVersion(t, page, "v1");
+    await stepTheCounter(t, page, 1, inc);
+    await stepTheCounter(t, page, 2, inc);
+    await stepTheCounter(t, page, 3, inc);
+    await clickLink(page, "#nav-decrement");
+    await stepTheCounter(t, page, 2, dec);
+    await modifyElmCode(t, testName, page, "v1", "v2");
+    await stepTheCounter(t, page, 1, dec);
+    await clickLink(page, "#nav-increment");
+    await stepTheCounter(t, page, 2, inc);
+    await modifyElmCode(t, testName, page, "v2", "v3");
+    await stepTheCounter(t, page, 3, inc);
+    await stepTheCounter(t, page, 4, inc);
+    await modifyElmCode(t, testName, page, "v3", "v4");
+    await stepTheCounter(t, page, 5, inc);
+    await modifyElmCode(t, testName, page, "v4", "v5");
+    await clickLink(page, "#nav-decrement");
+    await stepTheCounter(t, page, 4, dec);
+    await stepTheCounter(t, page, 3, dec);
+    await clickLink(page, "#nav-increment");
+    await stepTheCounter(t, page, 4, inc);
 }
 
 


### PR DESCRIPTION
The problem was that the Elm debugger wraps the user's model
with a bunch of extra stuff. So when we tried to find the
Browser.Navigation.Key at the top-level, we failed.

Fixes #5