### PR TITLE
Move scope function call into condition body

### DIFF
--- a/resources/hmr.js
+++ b/resources/hmr.js
@@ -423,6 +423,7 @@ if (module.hot) {
             });
         }
     })();
+    
+    scope['_elm_hot_loader_init'](scope['Elm']);
 }
 //////////////////// HMR END ////////////////////
-scope['_elm_hot_loader_init'](scope['Elm']);


### PR DESCRIPTION
I found this through `elm-hot-webpack-loader`, and couldn't get the compiled Elm app to run unless I made this change. I was getting the message `scope['_elm_hot_loader_init'](scope['Elm']) is undefined`.

I'm not sure if I'm missing something bigger-picture, but this seems to have solved the issue for me. Hope it helps!