### PR TITLE
Add 'height: inherit' to the injected DOM container node

### DIFF
--- a/resources/hmr.js
+++ b/resources/hmr.js
@@ -154,6 +154,7 @@ if (module.hot) {
             // behind their back and rudely put stuff in their DOM.
             var dummyNode = document.createElement("div");
             dummyNode.setAttribute("data-elm-hot", "true");
+            dummyNode.style.height = "inherit";
             var parentNode = node.parentNode;
             parentNode.replaceChild(dummyNode, node);
             dummyNode.appendChild(node);


### PR DESCRIPTION
This was necessary so that elm-ui's "height fill" feature can work
correctly. See https://github.com/halfzebra/create-elm-app/issues/320.

Fixes #22 