### PR TITLE
Improve Elm version check

### DIFF
--- a/resources/hmr.js
+++ b/resources/hmr.js
@@ -44,11 +44,11 @@ if (module.hot) {
         }
 
         // Elm 0.19.1 introduced a '$' prefix at the beginning of the symbols it emits,
-        // and we check for `List.map` because we expect it to be present in all Elm programs.
+        // and we check for `Maybe.Just` because we expect it to be present in all Elm programs.
         var elmVersion;
-        if (typeof elm$core$List$map !== 'undefined')
+        if (typeof elm$core$Maybe$Just !== 'undefined')
             elmVersion = '0.19.0';
-        else if (typeof $elm$core$List$map !== 'undefined')
+        else if (typeof $elm$core$Maybe$Just !== 'undefined')
             elmVersion = '0.19.1';
         else
             throw new Error("Could not determine Elm version");


### PR DESCRIPTION
This should be good enough, although I still don't like it. The problem
is that there is no explicit information in the generated code which
identifies the compiler version. And the dead code elimination is so
good that it _may_ even strip away foundational stuff from the core
library.

Fixes #28 