### PR TITLE
Fix crash when Json.Decode.Value holds a `null` in the model

### DIFF
--- a/resources/hmr.js
+++ b/resources/hmr.js
@@ -356,7 +356,7 @@ if (module.hot) {
             while (queue.length !== 0) {
                 var item = queue.shift();
 
-                if (typeof item.value === "undefined") {
+                if (typeof item.value === "undefined" || item.value === null) {
                     continue;
                 }
 


### PR DESCRIPTION
Looks like the navigation key search is crashing when it finds a JSON null value.

You can replicate the issue with a model like this one:

```elm
model =
    { value : Json.Encode.null }
```
I am not familiar enough with the codebase to know if skipping null values can have any consequences, but this seems to fix the issue.