### PR TITLE
Add a test for Browser.Application apps whose model contains 'null'

### DIFF
--- a/test/fixtures/BrowserApplicationWithNull.elm
+++ b/test/fixtures/BrowserApplicationWithNull.elm
@@ -1,0 +1,139 @@
+module BrowserApplicationWithNull exposing (..)
+
+import Browser exposing (UrlRequest)
+import Browser.Navigation as Nav
+import Html exposing (a, button, div, h1, p, span, text)
+import Html.Attributes exposing (href, id)
+import Html.Events exposing (onClick)
+import Json.Encode
+import Url exposing (Url)
+
+
+main =
+    Browser.application
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = \_ -> Sub.none
+        , onUrlRequest = LinkClicked
+        , onUrlChange = UrlChanged
+        }
+
+
+type alias Flags =
+    { n : Int }
+
+
+type alias Model =
+    { count : Int
+    , foo : Json.Encode.Value
+    , nav : { key : Nav.Key }
+    , page : Page
+    }
+
+
+type Page
+    = NotFound
+    | Incrementer
+    | Decrementer
+
+
+init : Flags -> Url -> Nav.Key -> ( Model, Cmd Msg )
+init flags url key =
+    ( loadPage url
+        { count = flags.n
+        , foo = Json.Encode.null
+        , nav = { key = key }
+        , page = NotFound
+        }
+    , Cmd.none
+    )
+
+
+type Msg
+    = Increment
+    | Decrement
+    | LinkClicked UrlRequest
+    | UrlChanged Url
+
+
+update msg model =
+    case msg of
+        Increment ->
+            ( { model | count = model.count + 1 }
+            , Cmd.none
+            )
+
+        Decrement ->
+            ( { model | count = model.count - 1 }
+            , Cmd.none
+            )
+
+        LinkClicked req ->
+            case req of
+                Browser.Internal url ->
+                    ( model, Nav.pushUrl model.nav.key (Url.toString url) )
+
+                Browser.External href ->
+                    ( model, Nav.load href )
+
+        UrlChanged url ->
+            ( loadPage url model
+            , Cmd.none
+            )
+
+
+loadPage : Url -> Model -> Model
+loadPage url model =
+    { model
+        | page =
+            case url.fragment of
+                Nothing ->
+                    Incrementer
+
+                Just "/incrementer" ->
+                    Incrementer
+
+                Just "/decrementer" ->
+                    Decrementer
+
+                _ ->
+                    NotFound
+    }
+
+
+view model =
+    let
+        pageBody =
+            case model.page of
+                Incrementer ->
+                    div [ id "incrementer" ]
+                        [ h1 [] [ text "Incrementer" ]
+                        , p []
+                            [ text "Counter value is: "
+                            , span [ id "counter-value" ] [ text (String.fromInt model.count) ]
+                            ]
+                        , button [ onClick Increment, id "counter-button" ] [ text "+" ]
+                        , p [] [ text "Switch to ", a [ id "nav-decrement", href "#/decrementer" ] [ text "decrementer" ] ]
+                        ]
+
+                Decrementer ->
+                    div [ id "decrementer" ]
+                        [ h1 [] [ text "Decrementer" ]
+                        , p []
+                            [ text "Counter value is: "
+                            , span [ id "counter-value" ] [ text (String.fromInt model.count) ]
+                            ]
+                        , button [ onClick Decrement, id "counter-button" ] [ text "-" ]
+                        , p [] [ text "Switch to ", a [ id "nav-increment", href "#/incrementer" ] [ text "incrementer" ] ]
+                        ]
+
+                NotFound ->
+                    text "Page not found"
+    in
+    { title = "BrowserApplicationCounter"
+    , body =
+        [ span [ id "code-version" ] [ text "code: v1" ]
+        , pageBody
+        ]
+    }

--- a/test/fixtures/BrowserApplicationWithNull.html
+++ b/test/fixtures/BrowserApplicationWithNull.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Main</title>
+    <script type="text/javascript" src="client.js"></script>
+    <script type="text/javascript" src="build/BrowserApplicationWithNull.js"></script>
+</head>
+
+<body>
+    <script>
+        connect("BrowserApplicationWithNull");
+        Elm.BrowserApplicationWithNull.init({
+            flags: {
+                n: 0
+            }
+        });
+    </script>
+</body>
+</html>

--- a/test/fixtures/elm.json
+++ b/test/fixtures/elm.json
@@ -9,10 +9,10 @@
             "elm/browser": "1.0.2",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",
+            "elm/json": "1.1.3",
             "elm/url": "1.0.0"
         },
         "indirect": {
-            "elm/json": "1.1.3",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2"
         }

--- a/test/test.js
+++ b/test/test.js
@@ -165,6 +165,11 @@ test('ports are reconnected after HMR (fullscreen case)', async t => {
     await doCounterTest(t, "PortsFullscreen");
 });
 
+test('an Elm model containing `null` should not crash', async t => {
+    // see https://github.com/klazuka/elm-hot/pull/36
+    await doCounterTest(t, "BrowserApplicationWithNull");
+});
+
 async function doCounterTest(t, testName) {
     const page = t.context.page;
     await page.goto(`${t.context.serverUrl}/${testName}.html`);


### PR DESCRIPTION
This was fixed in a previous PR, but it needed a test.