### PR TITLE
Don't treat Nav Key to move as an error

### DIFF
--- a/resources/hmr.js
+++ b/resources/hmr.js
@@ -423,8 +423,6 @@ if (module.hot) {
                             error = "could not find Browser.Navigation.Key in the new app model";
                         } else if (oldKeyLoc === null) {
                             error = "could not find Browser.Navigation.Key in the old app model.";
-                        } else if (newKeyLoc.keypath.toString() !== oldKeyLoc.keypath.toString()) {
-                            error = "the location of the Browser.Navigation.Key in the model has changed.";
                         } else {
                             // remove event listeners attached to the old nav key
                             removeNavKeyListeners(oldKeyLoc.value);


### PR DESCRIPTION
About a year ago an issue was fixed where moving the Navigation Key in the application Model would make Hot Reloading fail. While the logic to detect the new location of the key was implemented, the code still seems to treat the move as an error condition.

The fix was in `1.1.4`:

> fixed a bug where HMR failed because Browser.Navigation.Key changed location 

It seems that the check for what was previously considered an error is still in place. This PR will remove that check and just update the key.