### PR TITLE
docs: Update dead link to Parcel

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package provides the core infrastructure needed for doing hot code swapping
 
 **This low-level package is intended for authors of Elm application servers.**
 
-If you're looking for something that's easier to use, and you're willing to use Webpack, see [elm-hot-webpack-loader](https://github.com/klazuka/elm-hot-webpack-loader), which is built using this package. Another option is Parcel which has [built-in support for Elm](https://parceljs.org/elm.html) and this package.
+If you're looking for something that's easier to use, and you're willing to use Webpack, see [elm-hot-webpack-loader](https://github.com/klazuka/elm-hot-webpack-loader), which is built using this package. Another option is Parcel which has [built-in support for Elm](https://parceljs.org/languages/elm/) and this package.
 
 The goal of this package is to provide a reusable core that can be used to provide hot code swapping support in a variety of environments--not just Webpack.
 


### PR DESCRIPTION
I couldn't find URL changed commit in https://github.com/parcel-bundler/website, however it looks applied new URL.

<img width="775" alt="parcel-old" src="https://user-images.githubusercontent.com/1180335/176569487-23692b84-48bc-4bff-973f-7ee77d9aa1af.png">
<img width="667" alt="parcel-new" src="https://user-images.githubusercontent.com/1180335/176569484-b1b825fb-c016-44d6-acf9-3f9b68aa5ba8.png">

